### PR TITLE
eslint-config: add @typescript/parser as peer deps for typescript

### DIFF
--- a/.github/workflows/pull-changelog.yml
+++ b/.github/workflows/pull-changelog.yml
@@ -43,7 +43,7 @@ jobs:
           }
 
           const versionLabel = versionLabelsPresent[0];
-          console.log(`::set-output name=version-label::${versionLabel}`)
+          console.log(`::set-output name=versionLabel::${versionLabel}`)
 
           const packageLabels = labels.filter(name => name.includes('packages/'));
 
@@ -58,8 +58,9 @@ jobs:
           console.log(`::set-output name=package::${packageLabels[0]}`)
 
     - name: Fail if no changelog change when needed
-      if: >
-        steps.labels.outputs.version-label != 'Action: no bump'
+      if: |
+        steps.labels.outputs.versionLabel != 'Action: no bump'
+        && steps.labels.outputs.versionLabel != 'Action: beta bump'
       uses: actions/github-script@0.4.0
       env:
         PACKAGE: ${{ steps.labels.outputs.package }}

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Remove @typescript-eslint/parser from dependencies as it should be seen as a peer dependency
+
 ## [1.1.1]
 
 ### Changed

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -45,6 +45,10 @@ Note that all configs can be used on JSON files too.
 
 ### Typescript
 
+You will need to install a peer-dependency [`@typescript-eslint/parser`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser) 
+as [it is required by `eslint-plugin-import`](https://github.com/benmosher/eslint-plugin-import#typescript)
+internally.
+
 We lint typescript files with @typescript-eslint/eslint-plugin that provide
 rules that replace default eslint ones.
 

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -86,11 +86,6 @@
         }
       }
     },
-    "@types/eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
-    },
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -122,17 +117,6 @@
         "@types/json-schema": "^7.0.3",
         "@typescript-eslint/typescript-estree": "2.23.0",
         "eslint-scope": "^5.0.0"
-      }
-    },
-    "@typescript-eslint/parser": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.23.0.tgz",
-      "integrity": "sha512-k61pn/Nepk43qa1oLMiyqApC6x5eP5ddPz6VUYXCAuXxbmRLqkPYzkFRKl42ltxzB2luvejlVncrEpflgQoSUg==",
-      "requires": {
-        "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.23.0",
-        "@typescript-eslint/typescript-estree": "2.23.0",
-        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.7.0",


### PR DESCRIPTION
What this PR does / why we need it:
`@typescript/parser` is required as an optional peer-dependency if we want to lint TS, because it's required by  https://github.com/benmosher/eslint-plugin-import#typescript

Which issue(s) this PR fixes:

- Fixes #

