### PR TITLE
NO-TICKET: add arrow-body-style': ['error', 'as-needed']

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Change
+
+- Added `'arrow-body-style': ['error', 'as-needed']`
+
 ## [2.2.0]
 
 ### Change

--- a/packages/eslint-config/shared/javascript.js
+++ b/packages/eslint-config/shared/javascript.js
@@ -40,6 +40,8 @@ module.exports = {
     'eslint-comments/no-unlimited-disable': 'error',
     'eslint-comments/no-unused-disable': 'error',
     'eslint-comments/no-unused-enable': 'error',
+
+    'arrow-body-style': ['error', 'as-needed'],
   },
   overrides: [
     {


### PR DESCRIPTION
What this PR does / why we need it:

Enforce no useless `return` keyword in arrow functions

```
// bad
const pouet = (a: string) => {
  return a;
};

// good
const pouet = (a: string) => a;
```